### PR TITLE
Fixed driver controller reset

### DIFF
--- a/src/main/java/frc/robot/subsystems/OI.java
+++ b/src/main/java/frc/robot/subsystems/OI.java
@@ -18,6 +18,11 @@ public class OI
     }
 
     public static void zeroDriverController() {
+        //Sets all the offsets to zero, then uses whatever value it returns as the new offset.
+        LEFT_X_ZERO = 0;
+        LEFT_Y_ZERO = 0;
+        RIGHT_X_ZERO = 0;
+        RIGHT_Y_ZERO = 0;
         LEFT_X_ZERO = getDriverLeftX();
         LEFT_Y_ZERO = getDriverLeftY();
         RIGHT_X_ZERO = getDriverRightX();


### PR DESCRIPTION
It wasn't setting the offsets to be zero, which caused it to alternate between good and non-good states when you zero it again.