### PR TITLE
Climber fix

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -1,0 +1,11 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot;
+
+/** Add your docs here. */
+public class Constants {
+    public static final double ACCEPTABLE_FLYWHEEL_ERROR = 15.0; //Units: radians/second
+    public static final double ACCEPTABLE_HOOD_ERROR = 0.1; //Units: radians
+}

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -32,7 +32,7 @@ public class Robot extends TimedRobot
   public void robotInit() 
   {
     robotContainer = new RobotContainer();
-    // bling = robotContainer.bling;
+    bling = robotContainer.bling;
   }
 
   @Override

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -131,7 +131,7 @@ public class RobotContainer {
   public Command getTeleopCommand() {
     // Return the command that will run during teleop ('return null' means no
     // command will be run)
-    return hangStartPositioning;
+    return null;
   }
 
   public Command getTestCommand() {

--- a/src/main/java/frc/robot/Utility.java
+++ b/src/main/java/frc/robot/Utility.java
@@ -1,0 +1,16 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot;
+
+/** Add your docs here. */
+public class Utility {
+    public static double deadzone(double rawAxisValue, double deadzone) {
+        if (Math.abs(rawAxisValue) < deadzone) {
+            return 0;
+        } else {
+            return Math.signum(rawAxisValue) * (Math.abs(rawAxisValue) - deadzone) / (1 - deadzone);
+        }
+    }
+}

--- a/src/main/java/frc/robot/commands/ShooterTargetCommand.java
+++ b/src/main/java/frc/robot/commands/ShooterTargetCommand.java
@@ -1,0 +1,97 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import java.util.Map;
+
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.Constants;
+import frc.robot.components.InterpolatorTable;
+import frc.robot.components.InterpolatorTable.InterpolatorTableEntry;
+import frc.robot.subsystems.HubTracking;
+import frc.robot.subsystems.Shooter;
+import frc.robot.subsystems.HubTracking.HubData;
+
+public class ShooterTargetCommand extends CommandBase {
+
+  HubTracking hubTracking;
+  Shooter shooter;
+  HubData data;
+  double range = 0;
+  boolean dataCollected = false;
+
+  InterpolatorTable flywheelTable = new InterpolatorTable(
+    new InterpolatorTableEntry(0.0, 320),
+    new InterpolatorTableEntry(0.5, 350),
+    new InterpolatorTableEntry(1.0, 350),
+    new InterpolatorTableEntry(2.0, 370),
+    new InterpolatorTableEntry(3.0, 387),
+    new InterpolatorTableEntry(4.0, 418)
+  );
+
+  InterpolatorTable hoodTable = new InterpolatorTable(
+    new InterpolatorTableEntry(0.0, 0.08),
+    new InterpolatorTableEntry(0.5, 0.16),
+    new InterpolatorTableEntry(1.0, 0.21),
+    new InterpolatorTableEntry(2.0, 0.26),
+    new InterpolatorTableEntry(3.0, 0.338),
+    new InterpolatorTableEntry(4.0, 0.41)
+  );
+
+  double targetFlywheelVelocity = 0;
+  double targetHoodAngle = 0;
+
+  boolean overrideHubTracking;
+  double overrideDistance;
+
+  /** Creates a new ShooterTargetCommand. */
+  public ShooterTargetCommand(Shooter shooter_, HubTracking hubTracking_, boolean overrideHubTracking_, double overrideDistance_) {
+    hubTracking = hubTracking_;
+    shooter = shooter_;
+    overrideHubTracking = overrideHubTracking_;
+    overrideDistance = overrideDistance_;
+    
+    addRequirements(shooter);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+    range = 0;
+    targetFlywheelVelocity = 0;
+    targetHoodAngle = 0;
+    dataCollected = false;
+    if (overrideHubTracking) {
+      range = overrideDistance;
+      targetFlywheelVelocity = flywheelTable.getValue(range);
+      targetHoodAngle = hoodTable.getValue(range);
+    }
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+    if (!overrideHubTracking && !dataCollected) {
+      hubTracking.sampleHubData(data);
+      range = data.range;
+      if (range > 0) {
+        dataCollected = true;
+        targetFlywheelVelocity = flywheelTable.getValue(range);
+        targetHoodAngle = hoodTable.getValue(range);
+      }
+    }
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {}
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return Math.abs(targetHoodAngle - shooter.getHoodPosition()) <= Constants.ACCEPTABLE_HOOD_ERROR
+        && Math.abs(targetFlywheelVelocity - shooter.getFlywheelVelocity()) <= Constants.ACCEPTABLE_FLYWHEEL_ERROR;
+  }
+}

--- a/src/main/java/frc/robot/components/InterpolatorTable.java
+++ b/src/main/java/frc/robot/components/InterpolatorTable.java
@@ -4,6 +4,9 @@
 
 package frc.robot.components;
 
+import java.util.Map;
+import java.util.Set;
+
 /**
  * A component for generating output values based on a set of input-output pairs,
  * linearly interpolating between values and optionally either extrapolating past
@@ -13,6 +16,8 @@ package frc.robot.components;
 public class InterpolatorTable {
     private InterpolatorTableEntry[] entries;
 
+    private double minimumX = 0, maximumX = 0;
+
     /**
      * Constructs an InterpolatorTable object.
      * Optionally allows for extrapolation past the lower and upper bounds
@@ -21,6 +26,36 @@ public class InterpolatorTable {
      */
     public InterpolatorTable(InterpolatorTableEntry... entries_) {
         entries = entries_;
+        if (entries.length > 0) {
+            double lowestX = entries[0].x;
+            double highestX = entries[0].x;
+            for (InterpolatorTableEntry entry : entries) {
+                if (entry.x < lowestX) {
+                    lowestX = entry.x;
+                }
+                if (entry.x > highestX) {
+                    highestX = entry.x;
+                }
+            }
+            minimumX = lowestX;
+            maximumX = highestX;
+        }
+    }
+
+    /**
+     * Gets minimum of X domain.
+     * @return The minimum X value of any entry.
+     */
+    public double getMinimumX() {
+        return minimumX;
+    }
+
+    /**
+     * Gets minimum of X domain.
+     * @return The minimum X value of any entry.
+     */
+    public double getMaximumX() {
+        return maximumX;
     }
 
     public double getValue(double input) {
@@ -54,6 +89,7 @@ public class InterpolatorTable {
     public static class InterpolatorTableEntry {
         double x = 0;
         double y = 0;
+
         public InterpolatorTableEntry(double x_, double y_) {
             x = x_;
             y = y_;

--- a/src/main/java/frc/robot/components/InterpolatorTable.java
+++ b/src/main/java/frc/robot/components/InterpolatorTable.java
@@ -1,0 +1,62 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.components;
+
+/**
+ * A component for generating output values based on a set of input-output pairs,
+ * linearly interpolating between values and optionally either extrapolating past
+ * the domain of input points or clamping between the minimum or maximum.
+ */
+
+public class InterpolatorTable {
+    private InterpolatorTableEntry[] entries;
+
+    /**
+     * Constructs an InterpolatorTable object.
+     * Optionally allows for extrapolation past the lower and upper bounds
+     * (it clamps the input between the minimum and maximum otherwise)
+     * @param entries_ The array of entries
+     */
+    public InterpolatorTable(InterpolatorTableEntry... entries_) {
+        entries = entries_;
+    }
+
+    public double getValue(double input) {
+        int minIdx = -1;
+        int maxIdx = -1;
+        double minDistance = 1000000000;
+        double maxDistance = -1000000000;
+        for (int i = 0; i < entries.length; i++) {
+            double value = entries[i].x;
+            double distance = value - input;
+            if (distance < 0 && Math.abs(distance) < Math.abs(minDistance)) {
+                minIdx = i;
+                minDistance = distance;
+            } else if (distance >= 0 && Math.abs(distance) < Math.abs(maxDistance)) {
+                maxIdx = i;
+                maxDistance = distance;
+            }
+        }
+        if (minIdx == -1) {
+            return entries[maxIdx].y;
+        } else if (maxIdx == -1) {
+            return entries[minIdx].y;
+        }
+        double interpolationValue = (input - entries[minIdx].x) / (entries[maxIdx].x - entries[minIdx].x);
+        return entries[minIdx].y + (entries[maxIdx].y - entries[minIdx].y) * interpolationValue;
+    }
+
+    /**
+     * Simple struct for entries in InterpolatorTable.
+     */
+    public static class InterpolatorTableEntry {
+        double x = 0;
+        double y = 0;
+        public InterpolatorTableEntry(double x_, double y_) {
+            x = x_;
+            y = y_;
+        }
+    }
+}

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -21,6 +21,7 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 public class Shooter extends SubsystemBase {
   //ToF sensors
+  
   private DigitalInput tof1Input;
   private DutyCycle tof1DutyCycleInput;
   private double tof1Freq;


### PR DESCRIPTION
By reverting the merge commit that added in ShooterTesting to Climber-subsystem-Oli, we ended up deleting all the existing shooter code in a way that made GitHub refuse to recognize attempts to add that code back in (since we already did the merge commit, we can't redo it even though we reverted the changes). This code does build and doesn't crash, and all the mechanisms work (the only reason it was crashing before was because we commented out the bling object in Robot, which caused TeleopIndexer to raise a NullPointerException when we run Robot.getBling()).

I believe this merge should actually fix the problem, so hopefully we can get everything on main without having issues.