### PR TITLE
Climber now sets to coast mode from operator input

### DIFF
--- a/src/main/java/frc/robot/commands/TeleopClimber.java
+++ b/src/main/java/frc/robot/commands/TeleopClimber.java
@@ -30,9 +30,16 @@ public class TeleopClimber extends CommandBase {
   public void execute() {
     // climber.setSpoolVelocity(OI.operatorController.getLeftY());
     // climber.setExtensionVelocity(OI.operatorController.getRightY());
-
     climber.setSpoolVelocity(OI.operatorController.getLeftY() * spoolMultiplier);
-    climber.setExtensionVelocity(OI.operatorController.getRightY() * extensionMultiplier);
+    if (Math.abs(OI.operatorController.getRightY()) < 0.08) {
+      if(!climber.getExtensionMode()){climber.setExtensionBrake(true);}
+      climber.setExtensionVelocity(OI.operatorController.getRightY() * extensionMultiplier);      
+    } else {
+      if(climber.getExtensionMode()){
+        climber.setExtensionBrake(false);
+      }
+      climber.setExtensionPower(0);
+    }
   }
 
   // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/commands/TeleopClimber.java
+++ b/src/main/java/frc/robot/commands/TeleopClimber.java
@@ -23,7 +23,8 @@ public class TeleopClimber extends CommandBase {
 
   // Called when the command is initially scheduled.
   @Override
-  public void initialize() {}
+  public void initialize() {
+  }
 
   // Called every time the scheduler runs while the command is scheduled.
   @Override
@@ -31,14 +32,16 @@ public class TeleopClimber extends CommandBase {
     // climber.setSpoolVelocity(OI.operatorController.getLeftY());
     // climber.setExtensionVelocity(OI.operatorController.getRightY());
     climber.setSpoolVelocity(OI.operatorController.getLeftY() * spoolMultiplier);
-    if (Math.abs(OI.operatorController.getRightY()) < 0.08) {
-      if(!climber.getExtensionMode()){climber.setExtensionBrake(true);}
-      climber.setExtensionVelocity(OI.operatorController.getRightY() * extensionMultiplier);      
-    } else {
-      if(climber.getExtensionMode()){
+    if (OI.operatorController.getRightTriggerAxis() > 0.5) {
+      if (climber.getExtensionMode()) {
         climber.setExtensionBrake(false);
       }
       climber.setExtensionPower(0);
+    } else {
+      if (!climber.getExtensionMode()) {
+        climber.setExtensionBrake(true);
+      }
+      climber.setExtensionVelocity(OI.operatorController.getRightY() * extensionMultiplier);
     }
   }
 

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -61,6 +61,10 @@ public class Climber extends SubsystemBase {
   private double extension_kD = 0;
   private double extension_kF = 0.05;
 
+  private boolean extensionBrake = true;
+
+  private boolean extensionVelocityMode = true;
+
   /** Creates a new Climber. */
   public Climber() {
     spoolMotorRight = new WPI_TalonFX(44);
@@ -146,7 +150,9 @@ public class Climber extends SubsystemBase {
     // extensionMotorRight.set(ControlMode.Velocity, rawExtensionVel);
 
     spoolMotorRight.set(ControlMode.Velocity, rawSpoolVel);
-    extensionMotorRight.set(ControlMode.Velocity, rawExtensionVel);
+    if (extensionVelocityMode) {
+      extensionMotorRight.set(ControlMode.Velocity, rawExtensionVel);
+    }
 
     currentSpoolVelocity = spoolMotorRight.getSelectedSensorVelocity() / spoolTicksPerRadian * 10.0;
     currentExtensionVelocity = extensionMotorRight.getSelectedSensorVelocity() / extensionTicksPerRadian * 10.0;
@@ -185,6 +191,7 @@ public class Climber extends SubsystemBase {
   }
 
   public void setExtensionVelocity(double angularVelocity){
+    extensionVelocityMode = true;
     targetExtensionVelocity = angularVelocity;
   }
 
@@ -193,6 +200,7 @@ public class Climber extends SubsystemBase {
   }
 
   public void setExtensionPower(double power) {
+    extensionVelocityMode = false;
     extensionMotorRight.set(ControlMode.PercentOutput, power);
   }
 
@@ -204,15 +212,6 @@ public class Climber extends SubsystemBase {
     motor.setIntegralAccumulator(0);
     motor.configMaxIntegralAccumulator(0, max_integrator);
   }
-
-  /**
-   * Sets a *single* climber motor to a given angular velocity.
-   * This disables *all other motors*, and is meant to be used for indexing the climber.
-   * @param motor
-   * @param velocity
-   */
-  // public void setMotorVelocity(ClimberMotor motor, double velocity){
-  // }
 
   public boolean hasNotHung(){
     return true;
@@ -231,8 +230,6 @@ public class Climber extends SubsystemBase {
   public double getExtensionPosition(){
     return extensionMotorRight.getSelectedSensorPosition() / extensionTicksPerRadian;
   }
-
-
 
   // public double getMotorPosition(ClimberMotor motor){
   //   return 0;
@@ -255,5 +252,20 @@ public class Climber extends SubsystemBase {
     motor.configSupplyCurrentLimit(new SupplyCurrentLimitConfiguration(true, 20, 25, 0.25));
     motor.configSelectedFeedbackSensor(FeedbackDevice.IntegratedSensor);
     motor.setSelectedSensorPosition(0);
+  }
+
+  public void setExtensionBrake(boolean mode) {
+    extensionBrake = mode;
+    if (mode) {
+      extensionMotorRight.setNeutralMode(NeutralMode.Brake);
+      extensionMotorLeft.setNeutralMode(NeutralMode.Brake);
+    } else {
+      extensionMotorRight.setNeutralMode(NeutralMode.Coast);
+      extensionMotorLeft.setNeutralMode(NeutralMode.Coast);
+    }
+  }
+
+  public boolean getExtensionMode() {
+    return extensionBrake;
   }
 }

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -258,6 +258,7 @@ public class Climber extends SubsystemBase {
 
   public boolean getExtensionMode() {
     return extensionBrake;
+  }
 
    /**
    * sensorNumbers: 2 - left hook | 3 - left extension | 4 - right hook | 5 - right extension

--- a/src/main/java/frc/robot/subsystems/Climber.java
+++ b/src/main/java/frc/robot/subsystems/Climber.java
@@ -12,6 +12,8 @@ import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
 // import com.ctre.phoenix.sensors.CANCoder;
 
 import edu.wpi.first.math.filter.SlewRateLimiter;
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
@@ -68,10 +70,10 @@ public class Climber extends SubsystemBase {
   /** Creates a new Climber. */
   public Climber() {
     spoolMotorRight = new WPI_TalonFX(44);
-    extensionMotorRight = new WPI_TalonFX(17);
+    extensionMotorRight = new WPI_TalonFX(35);
     
     spoolMotorLeft = new WPI_TalonFX(32);
-    extensionMotorLeft = new WPI_TalonFX(35);
+    extensionMotorLeft = new WPI_TalonFX(17);
 
     resetSpoolMotor(spoolMotorRight);
     resetExtensionMotor(extensionMotorRight);
@@ -82,8 +84,8 @@ public class Climber extends SubsystemBase {
     spoolMotorLeft.setInverted(false);
     spoolMotorRight.setInverted(true);
 
-    extensionMotorLeft.setInverted(true);
-    extensionMotorRight.setInverted(false);
+    extensionMotorLeft.setInverted(false);
+    extensionMotorRight.setInverted(true);
 
     spoolMotorLeft.follow(spoolMotorRight);
     extensionMotorLeft.follow(extensionMotorRight);
@@ -138,6 +140,8 @@ public class Climber extends SubsystemBase {
     } else {
       Robot.getBling().setSlot(4, 0, 0, 0);
     }
+    
+    SmartDashboard.putNumber("[Climber] Output", spoolMotorLeft.getMotorOutputPercent());
 
     // This method will be called once per scheduler run
     double limitedSpoolVelocity = spoolFilter.calculate(targetSpoolVelocity);


### PR DESCRIPTION
Evan decided he wanted the shoulder release to be bound to an input on the controller rather than just happening when the input's near zero, but it works as intended. We also had the CAN IDs on the motors swapped, so I swapped them back and also swapped which one is inverted so it still goes in the same direction.